### PR TITLE
Improve accessibility

### DIFF
--- a/src/CalendarCell.tsx
+++ b/src/CalendarCell.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, useRef } from "react";
-import { useCalendarCell, useDateFormatter } from "react-aria";
+import { useCalendarCell, useDateFormatter, useId } from "react-aria";
 import { CalendarDate } from "@internationalized/date";
 import { CalendarState } from "react-stately";
 import "./CalendarCell.css";
@@ -21,11 +21,13 @@ export function CalendarCell({
     dateStyle: "full",
     timeZone: state.timeZone,
   });
+  const tooltipId = useId();
 
   return (
     <li {...cellProps} className="flex items-center justify-center group">
       <div
         {...buttonProps}
+        aria-labelledby={tooltipId}
         ref={ref}
         style={
           {
@@ -36,7 +38,7 @@ export function CalendarCell({
         className={`relative cell level${level}`}
       >
         <div className="absolute bottom-0 flex-col items-center hidden mb-6 w-max group-hover:flex">
-          <span className="relative z-10 p-2 text-xs leading-none text-white whitespace-no-wrap bg-black shadow-lg">
+          <span className="relative z-10 p-2 text-xs leading-none text-white whitespace-no-wrap bg-black shadow-lg" id={tooltipId}>
             {activity} activities on{" "}
             {formatter.format(date.toDate(state.timeZone))}
           </span>

--- a/src/CalendarGrid.tsx
+++ b/src/CalendarGrid.tsx
@@ -4,6 +4,13 @@ import { CalendarCell } from "./CalendarCell";
 import { numberOfLevels } from "./types";
 import "./CalendarGrid.css";
 
+const KEY_MAPPING: {[key: string]: string} = {
+  ArrowLeft: 'ArrowUp',
+  ArrowRight: 'ArrowDown',
+  ArrowUp: 'ArrowLeft',
+  ArrowDown: 'ArrowRight'
+};
+
 export function CalendarGrid({
   state,
   activities,
@@ -35,9 +42,15 @@ export function CalendarGrid({
   const max = Math.max(...activities);
   const interval = (max - min) / (numberOfLevels - 1);
 
+  const onKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    e.key = KEY_MAPPING[e.key] || e.key;
+    gridProps.onKeyDown!(e);
+  };
+
   return (
     <div
       {...gridProps}
+      onKeyDown={onKeyDown}
       className="p-5 m-5 inline-grid gap-2.5 grid-cols-[auto_1fr] [grid-template-areas:'empty_months'_'days_squares']"
     >
       <ul
@@ -48,7 +61,7 @@ export function CalendarGrid({
           return <li key={month}>{month}</li>;
         })}
       </ul>
-      <ul className="grid [grid-area:days] gap-[--square-gap] [grid-template-rows:repeat(7,_var(--square-size))]">
+      <ul aria-hidden="true" className="grid [grid-area:days] gap-[--square-gap] [grid-template-rows:repeat(7,_var(--square-size))]">
         {weekDays.map((weekDay) => {
           return (
             <li key={weekDay} className="odd:invisible">
@@ -57,7 +70,7 @@ export function CalendarGrid({
           );
         })}
       </ul>
-      <ul className="grid [grid-area:squares] gap-[--square-gap] [grid-template-rows:repeat(7,_var(--square-size))] grid-flow-col auto-cols-[--square-size]">
+      <ul role="row" className="grid [grid-area:squares] gap-[--square-gap] [grid-template-rows:repeat(7,_var(--square-size))] grid-flow-col auto-cols-[--square-size]">
         {activities.map((activity, index) => {
           const currentDate = state.visibleRange.start.add({ days: index });
 


### PR DESCRIPTION
First of all, nice work on this! It was so cool to see that React Aria is capable of building a type of UI that we didn't even imagine. 😍 

This fixes a couple small accessibility things I noticed:

1. The tooltips were not being read by screen readers, so when you focused on a date it would only read the date and not how many activities had occurred. This uses the `aria-labelledby` attribute on the button pointing at the tooltip element so that it reads that as the label.
2. The keyboard navigation seemed backward because React Aria is expecting weeks to be arranged horizontally rather than vertically. This intercepts the keyboard events and adjusts the key so that it behaves in the opposite orientation.
3. The cells were announcing as part of a list instead of a grid. That's because of the use of a `<ul>` element inside the grid. This adds `role="row"` there since table elements were not in use to get that automatically. It also hides the headers on the left with `aria-hidden` just like the ones on top.

Again, great work. This is super minor stuff but thought I'd send a PR anyway. Cheers! 🍻 